### PR TITLE
add prettierrc, clean up html, set max width for content

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": false,
+  "jsxSingleQuote": false
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,12 +5,14 @@ import Footer from "./components/Footer";
 
 function App() {
   return (
-    <div>
-      <Hero />
-      <About />
-      <Projects />
+    <>
+      <main>
+        <Hero />
+        <About />
+        <Projects />
+      </main>
       <Footer />
-    </div>
+    </>
   );
 }
 

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -14,7 +14,7 @@ function About() {
   }, [isInView]);
 
   return (
-    <section className="flex flex-col">
+    <section className="flex flex-col items-center max-w-screen-2xl mx-auto my-0">
       <motion.div
         ref={ref}
         variants={{
@@ -26,7 +26,7 @@ function About() {
         transition={{ duration: 0.75, delay: 0.25 }}
         className="mt-10 text-center text-[#45505b] font-poppins"
       >
-        <h1 className="text-4xl font-raleway font-bold">ABOUT</h1>
+        <h2 className="text-4xl font-raleway font-bold">ABOUT</h2>
         <hr className="pt- w-24 inline-flex justify-center h-0.5 border-t-0 bg-blue-700 opacity-100 dark:opacity-50"></hr>
         <p className="mt-4 mx-12 lg:mx-32 xl:mx-60 2xl:mx-80">
           I am an Undergraduate Senior Student at Florida State University. I
@@ -39,15 +39,15 @@ function About() {
         </p>
         <div className="lg:grid grid-cols-2">
           <img
-            className="object-scale-down h-52 lg:h-80 lg:ml-12 xl:ml-24 2xl:ml-36 w-full mt-8"
+            className="object-scale-down h-52 lg:h-80  w-full mt-8"
             src={ProfilePicture}
             alt="A picture of David Silva"
             title="David Silva"
           ></img>
           <div className="lg:flex flex-col lg:items-start lg:text-start">
-            <h1 className="mt-6 mb-2 font-raleway font-bold text-[#728394] text-2xl">
+            <h2 className="mt-6 mb-2 font-raleway font-bold text-[#728394] text-2xl">
               Aspiring Software Engineer
-            </h1>
+            </h2>
             <div className="flex flex-row justify-center text-start">
               <ul className="my-4">
                 <li>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -31,51 +31,52 @@ function Hero() {
     <section
       ref={ref}
       id="hero"
-      className="h-screen flex flex-col bg-hero_background bg-center bg-cover bg-blend-overlay bg-white/60"
+      className="h-screen flex flex-col bg-hero_background bg-center bg-cover bg-blend-overlay bg-white/60 justify-center"
     >
-      <div className="flex flex-1 items-center md:mb-0 ">
-        <motion.div
-          variants={{
-            hidden: { opacity: 0, y: 75 },
-            visible: { opacity: 1, y: 0 },
-          }}
-          initial="hidden"
-          animate={mainControls}
-          transition={{ duration: 0.75, delay: 0.25 }}
-          className="text-center mx-auto text-[#45505b] min-w-full"
+      <motion.div
+        variants={{
+          hidden: { opacity: 0, y: 75 },
+          visible: { opacity: 1, y: 0 },
+        }}
+        initial="hidden"
+        animate={mainControls}
+        transition={{ duration: 0.75, delay: 0.25 }}
+        className="text-center mx-auto text-[#45505b] min-w-full flex flex-col  items-center md:mb-0 "
+      >
+        <h1 className="font-raleway font-bold text-5xl">David Silva</h1>
+        <p
+          className="font-poppins text-3xl mt-2 "
+          aria-label={`I'm an Undergraduate Student and aspiring Software Engineer`}
         >
-          <h1 className="font-raleway font-bold text-5xl">David Silva</h1>
-          <p className="font-poppins text-3xl mt-2 ">
-            I'm an <span className="auto-type text-[#0563bb]"></span>
-          </p>
-          <div className="text-2xl md:text-3xl flex flex-row space-x-8 mt-5 justify-center">
-            <a
-              href="https://github.com/Daverhan"
-              target="_blank"
-              title="David Silva's GitHub Account"
-              className="hover:text-[#0563bb]"
-            >
-              <AiFillGithub />
-            </a>
-            <a
-              href="https://www.instagram.com/daverhan/"
-              target="_blank"
-              title="David Silva's Instagram Account"
-              className="hover:text-[#0563bb]"
-            >
-              <AiFillInstagram />
-            </a>
-            <a
-              href="https://www.linkedin.com/in/david-anthony-silva/"
-              target="_blank"
-              title="David Silva's LinkedIn Account"
-              className="hover:text-[#0563bb]"
-            >
-              <AiFillLinkedin />
-            </a>
-          </div>
-        </motion.div>
-      </div>
+          I'm an <span className="auto-type text-[#0563bb]"></span>
+        </p>
+        <div className="text-2xl md:text-3xl flex flex-row space-x-8 mt-5 justify-center">
+          <a
+            href="https://github.com/Daverhan"
+            target="_blank"
+            title="David Silva's GitHub Account"
+            className="hover:text-[#0563bb]"
+          >
+            <AiFillGithub />
+          </a>
+          <a
+            href="https://www.instagram.com/daverhan/"
+            target="_blank"
+            title="David Silva's Instagram Account"
+            className="hover:text-[#0563bb]"
+          >
+            <AiFillInstagram />
+          </a>
+          <a
+            href="https://www.linkedin.com/in/david-anthony-silva/"
+            target="_blank"
+            title="David Silva's LinkedIn Account"
+            className="hover:text-[#0563bb]"
+          >
+            <AiFillLinkedin />
+          </a>
+        </div>
+      </motion.div>
     </section>
   );
 }

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -13,7 +13,7 @@ function Projects() {
   }, [isInView]);
 
   return (
-    <section className="flex flex-col">
+    <section className="mx-auto my-0 max-w-screen-2xl">
       <motion.div
         ref={ref}
         variants={{
@@ -25,7 +25,7 @@ function Projects() {
         transition={{ duration: 0.75, delay: 0.25 }}
         className="mt-10 text-center text-[#45505b] font-poppins"
       >
-        <h1 className="text-4xl font-raleway font-bold">PROJECTS</h1>
+        <h2 className="text-4xl font-raleway font-bold">PROJECTS</h2>
         <hr className="pt- w-36 inline-flex justify-center h-0.5 border-t-0 bg-blue-700 opacity-100 dark:opacity-50"></hr>
         <p className="mt-4 mx-12">
           My GitHub will contain more in-depth information pertaining to each of


### PR DESCRIPTION
This PR mainly cleans up the semantic html used by doing the following
- Removing unnecessary divs. Divs with the purpose of wrapping the motion div have been removed. The tailwind classes were moved to the parent tag.
- Replacing `<h1>` tags except the first with `<h2>` tags. A page should only have one instance of an h1 tag.

I also set a max-width for certain parts of the site using taildwind's `max-w-screen-2xl'
 so that content does not seem blown out when viewing on wide displays.